### PR TITLE
Add a S3 endpoint to the network stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following resources will be created:
  - Nat Gateway
  - Network Access Control List (NACL) for all subnets
  - Database Subnet group - Provides an RDS DB subnet group resources
+ - S3 VPC endpoint
 
 
 

--- a/s3-endpoint.tf
+++ b/s3-endpoint.tf
@@ -13,9 +13,9 @@ resource "aws_vpc_endpoint" "s3" {
     POLICY
 
   lifecycle {
-    ignore_changes = [ policy ]
+    ignore_changes = [policy]
   }
-  
+
   tags = merge(
     var.tags,
     {
@@ -24,6 +24,6 @@ resource "aws_vpc_endpoint" "s3" {
     },
   )
 
-  depends_on = [ aws_vpc.default ]
+  depends_on = [aws_vpc.default]
 
 }

--- a/s3-endpoint.tf
+++ b/s3-endpoint.tf
@@ -1,0 +1,29 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = aws_vpc.default.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  policy = <<POLICY
+    {
+        "Statement": [
+            {
+                "Action": "*","Effect": "Allow","Resource": "*","Principal": "*"
+            }
+        ]
+    }
+    POLICY
+
+  lifecycle {
+    ignore_changes = [ policy ]
+  }
+  
+  tags = merge(
+    var.tags,
+    {
+      "Name"    = "${var.name}-S3-Endpoint"
+      "EnvName" = var.name
+    },
+  )
+
+  depends_on = [ aws_vpc.default ]
+
+}

--- a/subnet-private.tf
+++ b/subnet-private.tf
@@ -61,6 +61,12 @@ resource aws_route_table_association "private" {
   }
 }
 
+resource "aws_vpc_endpoint_route_table_association" "private" {
+  count           = length(aws_subnet.private)
+  route_table_id  = var.multi_nat ? aws_route_table.private[count.index].id : aws_route_table.private[0].id
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+}
+
 # resource "aws_route_table_association" "private_single" {
 #   count          = var.nat_count == length(data.aws_availability_zones.available.names) ? 0 : 1
 #   subnet_id      = aws_subnet.private.*.id[count.index]

--- a/subnet-public.tf
+++ b/subnet-public.tf
@@ -52,3 +52,8 @@ resource "aws_route_table_association" "public" {
     create_before_destroy = true
   }
 }
+
+resource "aws_vpc_endpoint_route_table_association" "public" {
+  route_table_id  = aws_route_table.public.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+}

--- a/subnet-secure.tf
+++ b/subnet-secure.tf
@@ -44,3 +44,8 @@ resource "aws_route_table_association" "secure" {
     create_before_destroy = true
   }
 }
+
+resource "aws_vpc_endpoint_route_table_association" "secure" {
+  route_table_id  = aws_route_table.secure.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+}

--- a/subnet-transit.tf
+++ b/subnet-transit.tf
@@ -54,3 +54,9 @@ resource "aws_route_table_association" "transit" {
     create_before_destroy = true
   }
 }
+
+resource "aws_vpc_endpoint_route_table_association" "transit" {
+  count           = var.transit_subnet ? 1 : 0
+  route_table_id = aws_route_table.transit[0].id
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+}

--- a/subnet-transit.tf
+++ b/subnet-transit.tf
@@ -57,6 +57,6 @@ resource "aws_route_table_association" "transit" {
 
 resource "aws_vpc_endpoint_route_table_association" "transit" {
   count           = var.transit_subnet ? 1 : 0
-  route_table_id = aws_route_table.transit[0].id
+  route_table_id  = aws_route_table.transit[0].id
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
 }


### PR DESCRIPTION
- A VPC endpoint enables you to privately connect your VPC to supported AWS services. Instances in your VPC do not require public IP addresses to communicate with resources in the service. Traffic between your VPC and the other service does not leave the Amazon network.

