### PR TITLE
Add aws-cdk:subnet-name and aws-cdk:subnet-type tags to subnets

### DIFF
--- a/subnet-private.tf
+++ b/subnet-private.tf
@@ -14,9 +14,11 @@ resource "aws_subnet" "private" {
   tags = merge(
     var.tags,
     {
-      "Name"    = "${var.name}-Subnet-Private-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
-      "Scheme"  = "private"
-      "EnvName" = var.name
+      "Name"                = "${var.name}-Subnet-Private-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
+      "Scheme"              = "private"
+      "EnvName"             = var.name
+      "aws-cdk:subnet-name" = "Private"
+      "aws-cdk:subnet-type" = "Private"
     },
     local.kubernetes_clusters,
     length(var.kubernetes_clusters) != 0 ? { "kubernetes.io/role/internal-elb" = 1 } : {}

--- a/subnet-public.tf
+++ b/subnet-public.tf
@@ -12,9 +12,11 @@ resource "aws_subnet" "public" {
   tags = merge(
     var.tags,
     {
-      "Name"    = "${var.name}-Subnet-Public-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
-      "Scheme"  = "public"
-      "EnvName" = var.name
+      "Name"                = "${var.name}-Subnet-Public-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
+      "Scheme"              = "public"
+      "EnvName"             = var.name
+      "aws-cdk:subnet-name" = "Public"
+      "aws-cdk:subnet-type" = "Public"
     },
     local.kubernetes_clusters,
     length(var.kubernetes_clusters) != 0 ? { "kubernetes.io/role/elb" = 1 } : {}

--- a/subnet-secure.tf
+++ b/subnet-secure.tf
@@ -12,9 +12,11 @@ resource "aws_subnet" "secure" {
   tags = merge(
     var.tags,
     {
-      "Name"    = "${var.name}-Subnet-Secure-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
-      "Scheme"  = "secure"
-      "EnvName" = var.name
+      "Name"                = "${var.name}-Subnet-Secure-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
+      "Scheme"              = "secure"
+      "EnvName"             = var.name
+      "aws-cdk:subnet-name" = "Secure"
+      "aws-cdk:subnet-type" = "Isolated"
     },
     local.kubernetes_clusters_secure,
     length(var.kubernetes_clusters_secure) != 0 ? { "kubernetes.io/role/internal-elb" = 1 } : {}

--- a/subnet-transit.tf
+++ b/subnet-transit.tf
@@ -12,9 +12,11 @@ resource "aws_subnet" "transit" {
   tags = merge(
     var.tags,
     {
-      "Name"    = "${var.name}-Subnet-Transit-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
-      "Scheme"  = "transit"
-      "EnvName" = var.name
+      "Name"                = "${var.name}-Subnet-Transit-${upper(data.aws_availability_zone.az[count.index].name_suffix)}"
+      "Scheme"              = "transit"
+      "EnvName"             = var.name
+      "aws-cdk:subnet-name" = "Transit"
+      "aws-cdk:subnet-type" = "Public"
     },
   )
 }


### PR DESCRIPTION
This PR sees that the `aws-cdk:subnet-name` and `aws-cdk:subnet-type` tags are added to all provisioned  subnets. These tags are require by [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html) for resolving subnets on an existing deployed VPCs. See [the docs](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-ec2-readme.html#importing-an-existing-vpc) for further details.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

It's up for debate as to whether or not we add these tags based if a specific boolean variable is defined.