### PR TITLE
Adding creation of db Subnet Groups

### DIFF
--- a/_outputs.tf
+++ b/_outputs.tf
@@ -58,8 +58,16 @@ output "nat_gateway_ids" {
   description = "List of NAT Gateway IDs"
 }
 
-output "db_subnet_group_id" {
-  value = aws_db_subnet_group.secure.id
+output "db_subnet_group_secure_id" {
+  value = aws_db_subnet_group.secure[0].id
+}
+
+output "db_subnet_group_private_id" {
+  value = aws_db_subnet_group.private[0].id
+}
+
+output "db_subnet_group_public_id" {
+  value = aws_db_subnet_group.public[0].id
 }
 
 output "public_route_table_id" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -252,6 +252,24 @@ variable "enable_firewall_default_rule" {
   description = "Enable or disable the default stateful rule."
 }
 
+variable "create_dbsubgroup_secure" {
+  type        = bool
+  default     = true
+  description = "Create Secure Subgroup"
+}
+
+variable "create_dbsubgroup_public" {
+  type        = bool
+  default     = false
+  description = "Create Public Subgroup"
+}
+
+variable "create_dbsubgroup_private" {
+  type        = bool
+  default     = false
+  description = "Create Private Subgroup"
+}
+
 locals {
   kubernetes_clusters = zipmap(
     formatlist("kubernetes.io/cluster/%s", var.kubernetes_clusters),

--- a/cf-exports.tf
+++ b/cf-exports.tf
@@ -6,14 +6,16 @@ resource "aws_cloudformation_stack" "tf_exports" {
       "VpcId"              = aws_vpc.default.id,
       "CidrBlock"          = aws_vpc.default.cidr_block,
       "InternetGatewayId"  = aws_internet_gateway.default.id,
-      "PublicSubnetIds"    = join(",", aws_subnet.public[*].id),
-      "PublicSubnetCidrs"  = join(",", aws_subnet.public[*].cidr_block),
-      "PrivateSubnetIds"   = join(",", aws_subnet.private[*].id),
-      "PrivateSubnetCidrs" = join(",", aws_subnet.private[*].cidr_block),
-      "SecureSubnetIds"    = join(",", aws_subnet.secure[*].id),
-      "SecureSubnetCidrs"  = join(",", aws_subnet.secure[*].cidr_block),
-      "NatGatewayIds"      = var.nat ? join(",", aws_nat_gateway.nat_gw[*].id) : "undefined",
-      "DbSubnetGroupId"    = aws_db_subnet_group.secure.id
+      "PublicSubnetIds"    = join(",", aws_subnet.public.*.id),
+      "PublicSubnetCidrs"  = join(",", aws_subnet.public.*.cidr_block),
+      "PrivateSubnetIds"   = join(",", aws_subnet.private.*.id),
+      "PrivateSubnetCidrs" = join(",", aws_subnet.private.*.cidr_block),
+      "SecureSubnetIds"    = join(",", aws_subnet.secure.*.id),
+      "SecureSubnetCidrs"  = join(",", aws_subnet.secure.*.cidr_block),
+      "NatGatewayIds"      = var.nat ? join(",", aws_nat_gateway.nat_gw.*.id) : "undefined",
+      "DbSubnetGroupId"    = aws_db_subnet_group.secure[0].id,
+      "DbSubnetPrivateGroupId" = try(aws_db_subnet_group.private[0].id,"")
+      "DbSubnetPublicGroupId"  = try(aws_db_subnet_group.public[0].id,"")
     }
   })
 }

--- a/db-subnet.tf
+++ b/db-subnet.tf
@@ -1,13 +1,45 @@
 resource "aws_db_subnet_group" "secure" {
-  name       = lower(format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix))
-  subnet_ids = aws_subnet.secure[*].id
+  count      = var.create_dbsubgroup_secure ? 1 : 0
+  name       = lower("${format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix)}-secure")
+  subnet_ids = aws_subnet.secure.*.id
 
   tags = merge(
     var.tags,
     {
-      "Name"    = format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix)
+      "Name"    = "${format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix)}-secure"
       "Scheme"  = "secure"
       "EnvName" = var.name
     },
   )
 }
+
+resource "aws_db_subnet_group" "private" {
+  count      = var.create_dbsubgroup_private ? 1 : 0
+  name       = lower("${format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix)}-private")
+  subnet_ids = aws_subnet.private.*.id
+
+  tags = merge(
+    var.tags,
+    {
+      "Name"    = "${format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix)}-private"
+      "Scheme"  = "private"
+      "EnvName" = var.name
+    },
+  )
+}
+
+resource "aws_db_subnet_group" "public" {
+  count      = var.create_dbsubgroup_public ? 1 : 0
+  name       = lower("${format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix)}-public")
+  subnet_ids = aws_subnet.public.*.id
+
+  tags = merge(
+    var.tags,
+    {
+      "Name"    = "${format(local.names[var.name_pattern].db_subnet, var.name, local.name_suffix)}-public"
+      "Scheme"  = "public"
+      "EnvName" = var.name
+    },
+  )
+}
+


### PR DESCRIPTION
Added flags to enable the creation of additional db_subnet_groups for both private and public subnets. By default, secure remains trhe default, but now the configuration allows for the creation of up to two additional subnet groups (private and public).


