### PR TITLE
feat: add per-tier subnet sizing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ module "network" {
 | firewall\_custom\_rules | The stateful rule group rules specifications in Suricata file format, with one rule per line | `list(string)` | `[]` | no |
 | firewall\_domain\_list | List the domain names you want to take action on. | `list(any)` | <pre>[<br>  ".amazonaws.com",<br>  ".github.com"<br>]</pre> | no |
 | firewall\_netnum\_offset | Start with this subnet for secure ones, plus number of AZs | `number` | `14` | no |
+| firewall\_newbits | Number of bits to add to the vpc cidr for firewall subnets (overrides 'newbits' if set) | `number` | `null` | no |
 | kms\_key\_arn | The ARN of the KMS Key to use when encrypting log data. | `string` | `""` | no |
 | kubernetes\_clusters | List of kubernetes cluster names to creates tags in public and private subnets of this VPC | `list(string)` | `[]` | no |
 | kubernetes\_clusters\_secure | List of kubernetes cluster names to creates tags in secure subnets of this VPC | `list(string)` | `[]` | no |
@@ -104,9 +105,10 @@ module "network" {
 | name\_suffix | Adds a name suffix to all resources created | `string` | `""` | no |
 | nat | Deploy NAT instance(s) | `bool` | `true` | no |
 | network\_firewall | Enable or disable VPC Network Firewall | `bool` | `false` | no |
-| newbits | Number of bits to add to the vpc cidr when building subnets | `number` | `5` | no |
+| newbits | Number of bits to add to the vpc cidr when building subnets (applies to all tiers unless tier-specific values are set) | `number` | `5` | no |
 | private\_nacl\_allow\_cidrs | CIDRs to allow traffic from private subnet | `list(string)` | `[]` | no |
 | private\_netnum\_offset | Start with this subnet for private ones, plus number of AZs | `number` | `5` | no |
+| private\_newbits | Number of bits to add to the vpc cidr for private subnets (overrides 'newbits' if set) | `number` | `null` | no |
 | public\_nacl\_allow\_cidrs | CIDRs to allow traffic from public subnet | `list(string)` | `[]` | no |
 | public\_nacl\_icmp | Allows ICMP traffic to and from the public subnet | `bool` | `true` | no |
 | public\_nacl\_inbound\_tcp\_ports | TCP Ports to allow inbound on public subnet via NACLs (this list cannot be empty) | `list(string)` | <pre>[<br>  "80",<br>  "443",<br>  "22",<br>  "1194"<br>]</pre> | no |
@@ -114,13 +116,16 @@ module "network" {
 | public\_nacl\_outbound\_tcp\_ports | TCP Ports to allow outbound to external services (use [0] to allow all ports) | `list(string)` | <pre>[<br>  "0"<br>]</pre> | no |
 | public\_nacl\_outbound\_udp\_ports | UDP Ports to allow outbound to external services (use [0] to allow all ports) | `list(string)` | <pre>[<br>  "0"<br>]</pre> | no |
 | public\_netnum\_offset | Start with this subnet for public ones, plus number of AZs | `number` | `0` | no |
+| public\_newbits | Number of bits to add to the vpc cidr for public subnets (overrides 'newbits' if set) | `number` | `null` | no |
 | secure\_nacl\_allow\_cidrs | CIDRs to allow traffic from secure subnet | `list(string)` | `[]` | no |
 | secure\_nacl\_allow\_public | Allow traffic between public and secure | `bool` | `false` | no |
 | secure\_netnum\_offset | Start with this subnet for secure ones, plus number of AZs | `number` | `10` | no |
+| secure\_newbits | Number of bits to add to the vpc cidr for secure subnets (overrides 'newbits' if set) | `number` | `null` | no |
 | tags | Extra tags to attach to resources | `map(string)` | `{}` | no |
 | transit\_nacl\_inbound\_tcp\_ports | TCP Ports to allow inbound on transit subnet via NACLs (this list cannot be empty) | `list(string)` | <pre>[<br>  "1194"<br>]</pre> | no |
 | transit\_nacl\_inbound\_udp\_ports | UDP Ports to allow inbound on transit subnet via NACLs (this list cannot be empty) | `list(string)` | <pre>[<br>  "1194"<br>]</pre> | no |
 | transit\_netnum\_offset | Start with this subnet for secure ones, plus number of AZs | `number` | `15` | no |
+| transit\_newbits | Number of bits to add to the vpc cidr for transit subnets (overrides 'newbits' if set) | `number` | `null` | no |
 | transit\_subnet | Create a transit subnet for VPC peering (only central account) | `bool` | `false` | no |
 | vpc\_cidr | Network CIDR for the VPC | `string` | n/a | yes |
 | vpc\_cidr\_summ | Define cidr used to summarize subnets by tier | `string` | `"/0"` | no |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ module "network" {
 }
 ```
 
+### Per-Tier Subnet Sizing (Optional)
+
+For mixed subnet sizes, override `newbits` per tier:
+
+```hcl
+module "network" {
+  source   = "git::https://github.com/DNXLabs/terraform-aws-network.git"
+  
+  vpc_cidr = "10.39.32.0/21"
+  newbits  = 5  # Default /26
+  
+  # Override per tier
+  public_newbits  = 5  # /26 (62 IPs)
+  private_newbits = 3  # /24 (254 IPs)
+  secure_newbits  = 5  # /26 (62 IPs)
+}
+```
+
 <!--- BEGIN_TF_DOCS --->
 
 ## Requirements

--- a/_data.tf
+++ b/_data.tf
@@ -14,3 +14,12 @@ data "aws_ec2_managed_prefix_list" "s3" {
 data "aws_ec2_managed_prefix_list" "dynamodb" {
   name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
 }
+
+# Compute effective newbits per tier (tier-specific overrides global)
+locals {
+  public_newbits_effective   = coalesce(var.public_newbits, var.newbits)
+  private_newbits_effective  = coalesce(var.private_newbits, var.newbits)
+  secure_newbits_effective   = coalesce(var.secure_newbits, var.newbits)
+  transit_newbits_effective  = coalesce(var.transit_newbits, var.newbits)
+  firewall_newbits_effective = coalesce(var.firewall_newbits, var.newbits)
+}

--- a/_data.tf
+++ b/_data.tf
@@ -14,12 +14,3 @@ data "aws_ec2_managed_prefix_list" "s3" {
 data "aws_ec2_managed_prefix_list" "dynamodb" {
   name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
 }
-
-# Compute effective newbits per tier (tier-specific overrides global)
-locals {
-  public_newbits_effective   = coalesce(var.public_newbits, var.newbits)
-  private_newbits_effective  = coalesce(var.private_newbits, var.newbits)
-  secure_newbits_effective   = coalesce(var.secure_newbits, var.newbits)
-  transit_newbits_effective  = coalesce(var.transit_newbits, var.newbits)
-  firewall_newbits_effective = coalesce(var.firewall_newbits, var.newbits)
-}

--- a/_variables.tf
+++ b/_variables.tf
@@ -331,6 +331,13 @@ variable "db_subnet_group_secure_name_compat" {
 }
 
 locals {
+  # Compute effective newbits per tier (tier-specific overrides global)
+  public_newbits_effective   = coalesce(var.public_newbits, var.newbits)
+  private_newbits_effective  = coalesce(var.private_newbits, var.newbits)
+  secure_newbits_effective   = coalesce(var.secure_newbits, var.newbits)
+  transit_newbits_effective  = coalesce(var.transit_newbits, var.newbits)
+  firewall_newbits_effective = coalesce(var.firewall_newbits, var.newbits)
+
   kubernetes_clusters = zipmap(
     formatlist("kubernetes.io/cluster/%s", var.kubernetes_clusters),
     [for cluster in var.kubernetes_clusters : var.kubernetes_clusters_type]

--- a/_variables.tf
+++ b/_variables.tf
@@ -39,7 +39,37 @@ variable "multi_nat" {
 variable "newbits" {
   type        = number
   default     = 5
-  description = "Number of bits to add to the vpc cidr when building subnets"
+  description = "Number of bits to add to the vpc cidr when building subnets (applies to all tiers unless tier-specific values are set)"
+}
+
+variable "public_newbits" {
+  type        = number
+  default     = null
+  description = "Number of bits to add to the vpc cidr for public subnets (overrides 'newbits' if set)"
+}
+
+variable "private_newbits" {
+  type        = number
+  default     = null
+  description = "Number of bits to add to the vpc cidr for private subnets (overrides 'newbits' if set)"
+}
+
+variable "secure_newbits" {
+  type        = number
+  default     = null
+  description = "Number of bits to add to the vpc cidr for secure subnets (overrides 'newbits' if set)"
+}
+
+variable "transit_newbits" {
+  type        = number
+  default     = null
+  description = "Number of bits to add to the vpc cidr for transit subnets (overrides 'newbits' if set)"
+}
+
+variable "firewall_newbits" {
+  type        = number
+  default     = null
+  description = "Number of bits to add to the vpc cidr for firewall subnets (overrides 'newbits' if set)"
 }
 
 variable "vpc_cidr_summ" {

--- a/subnet-firewall.tf
+++ b/subnet-firewall.tf
@@ -4,7 +4,7 @@ resource "aws_subnet" "firewall" {
 
   cidr_block = cidrsubnet(
     aws_vpc.default.cidr_block,
-    var.newbits,
+    local.firewall_newbits_effective,
     count.index + var.firewall_netnum_offset,
   )
 

--- a/subnet-private.tf
+++ b/subnet-private.tf
@@ -4,7 +4,7 @@ resource "aws_subnet" "private" {
 
   cidr_block = cidrsubnet(
     aws_vpc.default.cidr_block,
-    var.newbits,
+    local.private_newbits_effective,
     count.index + var.private_netnum_offset,
   )
 

--- a/subnet-public.tf
+++ b/subnet-public.tf
@@ -3,7 +3,7 @@ resource "aws_subnet" "public" {
   vpc_id = aws_vpc.default.id
   cidr_block = cidrsubnet(
     aws_vpc.default.cidr_block,
-    var.newbits,
+    local.public_newbits_effective,
     count.index + var.public_netnum_offset,
   )
   availability_zone       = data.aws_availability_zones.available.names[count.index]

--- a/subnet-secure.tf
+++ b/subnet-secure.tf
@@ -3,7 +3,7 @@ resource "aws_subnet" "secure" {
   vpc_id = aws_vpc.default.id
   cidr_block = cidrsubnet(
     aws_vpc.default.cidr_block,
-    var.newbits,
+    local.secure_newbits_effective,
     count.index + var.secure_netnum_offset,
   )
   availability_zone       = data.aws_availability_zones.available.names[count.index]

--- a/subnet-transit.tf
+++ b/subnet-transit.tf
@@ -3,7 +3,7 @@ resource "aws_subnet" "transit" {
   vpc_id = aws_vpc.default.id
   cidr_block = cidrsubnet(
     aws_vpc.default.cidr_block,
-    var.newbits,
+    local.transit_newbits_effective,
     count.index + var.transit_netnum_offset,
   )
   availability_zone       = data.aws_availability_zones.available.names[count.index]


### PR DESCRIPTION
- Add optional per-tier newbits variables (public_newbits, private_newbits, etc.)
- Maintain 100% backward compatibility with existing 'newbits' variable
- Enable mixed subnet sizes within same VPC (e.g., /24 for private, /26 for transit)
- Update README with usage example


Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

Adds optional per-tier subnet sizing support for mixed subnet sizes within a VPC.

## Changes
- Add optional `public_newbits`, `private_newbits`, `secure_newbits`, `transit_newbits`, `firewall_newbits` variables
- Update all subnet resources to use tier-specific newbits
- Add usage example to README

## Backward Compatibility
✅ 100% backward compatible - existing configurations work unchanged
- If tier-specific variables not set, falls back to `newbits` (existing behavior)

## Use Case
Enables efficient IP allocation for hub-and-spoke architectures:
hcl
vpc_cidr        = "10.39.32.0/21"
newbits         = 5  # Default /26
private_newbits = 3  # Override: /24 for applications

## Testing
- [x] Terraform syntax validated
- [x] Backward compatibility maintained
- [x] Documentation updated

## Suggested Release
**v2.4.0** (minor version - new feature, backward compatible)