### PR TITLE
Add hostname-type variables for provisioning instances with ip-name or resource-name hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ module "network" {
 | firewall\_domain\_list | List the domain names you want to take action on. | `list(any)` | <pre>[<br>  ".amazonaws.com",<br>  ".github.com"<br>]</pre> | no |
 | firewall\_netnum\_offset | Start with this subnet for secure ones, plus number of AZs | `number` | `14` | no |
 | firewall\_newbits | Number of bits to add to the vpc cidr for firewall subnets (overrides 'newbits' if set) | `number` | `null` | no |
+| firewall\_hostname\_type | The type of hostnames to assign instances in the firewall subnets at launch. Valid values: `ip-name`, `resource-name`. | `string` | `null` | no |
 | kms\_key\_arn | The ARN of the KMS Key to use when encrypting log data. | `string` | `""` | no |
 | kubernetes\_clusters | List of kubernetes cluster names to creates tags in public and private subnets of this VPC | `list(string)` | `[]` | no |
 | kubernetes\_clusters\_secure | List of kubernetes cluster names to creates tags in secure subnets of this VPC | `list(string)` | `[]` | no |
@@ -109,6 +110,7 @@ module "network" {
 | private\_nacl\_allow\_cidrs | CIDRs to allow traffic from private subnet | `list(string)` | `[]` | no |
 | private\_netnum\_offset | Start with this subnet for private ones, plus number of AZs | `number` | `5` | no |
 | private\_newbits | Number of bits to add to the vpc cidr for private subnets (overrides 'newbits' if set) | `number` | `null` | no |
+| private\_hostname\_type | The type of hostnames to assign instances in the private subnets at launch. Valid values: `ip-name`, `resource-name`. | `string` | `null` | no |
 | public\_nacl\_allow\_cidrs | CIDRs to allow traffic from public subnet | `list(string)` | `[]` | no |
 | public\_nacl\_icmp | Allows ICMP traffic to and from the public subnet | `bool` | `true` | no |
 | public\_nacl\_inbound\_tcp\_ports | TCP Ports to allow inbound on public subnet via NACLs (this list cannot be empty) | `list(string)` | <pre>[<br>  "80",<br>  "443",<br>  "22",<br>  "1194"<br>]</pre> | no |
@@ -117,15 +119,18 @@ module "network" {
 | public\_nacl\_outbound\_udp\_ports | UDP Ports to allow outbound to external services (use [0] to allow all ports) | `list(string)` | <pre>[<br>  "0"<br>]</pre> | no |
 | public\_netnum\_offset | Start with this subnet for public ones, plus number of AZs | `number` | `0` | no |
 | public\_newbits | Number of bits to add to the vpc cidr for public subnets (overrides 'newbits' if set) | `number` | `null` | no |
+| public\_hostname\_type | The type of hostnames to assign instances in the public subnets at launch. Valid values: `ip-name`, `resource-name`. | `string` | `null` | no |
 | secure\_nacl\_allow\_cidrs | CIDRs to allow traffic from secure subnet | `list(string)` | `[]` | no |
 | secure\_nacl\_allow\_public | Allow traffic between public and secure | `bool` | `false` | no |
 | secure\_netnum\_offset | Start with this subnet for secure ones, plus number of AZs | `number` | `10` | no |
 | secure\_newbits | Number of bits to add to the vpc cidr for secure subnets (overrides 'newbits' if set) | `number` | `null` | no |
+| secure\_hostname\_type | The type of hostnames to assign instances in the secure subnets at launch. Valid values: `ip-name`, `resource-name`. | `string` | `null` | no |
 | tags | Extra tags to attach to resources | `map(string)` | `{}` | no |
 | transit\_nacl\_inbound\_tcp\_ports | TCP Ports to allow inbound on transit subnet via NACLs (this list cannot be empty) | `list(string)` | <pre>[<br>  "1194"<br>]</pre> | no |
 | transit\_nacl\_inbound\_udp\_ports | UDP Ports to allow inbound on transit subnet via NACLs (this list cannot be empty) | `list(string)` | <pre>[<br>  "1194"<br>]</pre> | no |
 | transit\_netnum\_offset | Start with this subnet for secure ones, plus number of AZs | `number` | `15` | no |
 | transit\_newbits | Number of bits to add to the vpc cidr for transit subnets (overrides 'newbits' if set) | `number` | `null` | no |
+| transit\_hostname\_type | The type of hostnames to assign instances in the transit subnets at launch. Valid values: `ip-name`, `resource-name`. | `string` | `null` | no |
 | transit\_subnet | Create a transit subnet for VPC peering (only central account) | `bool` | `false` | no |
 | vpc\_cidr | Network CIDR for the VPC | `string` | n/a | yes |
 | vpc\_cidr\_summ | Define cidr used to summarize subnets by tier | `string` | `"/0"` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -114,6 +114,36 @@ variable "firewall_netnum_offset" {
   description = "Start with this subnet for secure ones, plus number of AZs"
 }
 
+variable "public_hostname_type" {
+  type        = string
+  default     = null
+  description = "The type of hostnames to assign instances in the public subnets at launch. Valid values: `ip-name`, `resource-name`."
+}
+
+variable "private_hostname_type" {
+  type        = string
+  default     = null
+  description = "The type of hostnames to assign instances in the private subnets at launch. Valid values: `ip-name`, `resource-name`."
+}
+
+variable "secure_hostname_type" {
+  type        = string
+  default     = null
+  description = "The type of hostnames to assign instances in the secure subnets at launch. Valid values: `ip-name`, `resource-name`."
+}
+
+variable "transit_hostname_type" {
+  type        = string
+  default     = null
+  description = "The type of hostnames to assign instances in the transit subnets at launch. Valid values: `ip-name`, `resource-name`."
+}
+
+variable "firewall_hostname_type" {
+  type        = string
+  default     = null
+  description = "The type of hostnames to assign instances in the firewall subnets at launch. Valid values: `ip-name`, `resource-name`."
+}
+
 variable "firewall_custom_rules" {
   type        = list(string)
   default     = []

--- a/subnet-firewall.tf
+++ b/subnet-firewall.tf
@@ -8,8 +8,9 @@ resource "aws_subnet" "firewall" {
     count.index + var.firewall_netnum_offset,
   )
 
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = false
+  availability_zone                   = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch             = false
+  private_dns_hostname_type_on_launch = var.firewall_hostname_type
 
   tags = merge(
     var.tags,

--- a/subnet-private.tf
+++ b/subnet-private.tf
@@ -8,8 +8,9 @@ resource "aws_subnet" "private" {
     count.index + var.private_netnum_offset,
   )
 
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = false
+  availability_zone                   = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch             = false
+  private_dns_hostname_type_on_launch = var.private_hostname_type
 
   tags = merge(
     var.tags,

--- a/subnet-public.tf
+++ b/subnet-public.tf
@@ -6,8 +6,9 @@ resource "aws_subnet" "public" {
     local.public_newbits_effective,
     count.index + var.public_netnum_offset,
   )
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = true
+  availability_zone                   = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch             = true
+  private_dns_hostname_type_on_launch = var.public_hostname_type
 
   tags = merge(
     var.tags,

--- a/subnet-secure.tf
+++ b/subnet-secure.tf
@@ -6,8 +6,9 @@ resource "aws_subnet" "secure" {
     local.secure_newbits_effective,
     count.index + var.secure_netnum_offset,
   )
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = false
+  availability_zone                   = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch             = false
+  private_dns_hostname_type_on_launch = var.secure_hostname_type
 
   tags = merge(
     var.tags,

--- a/subnet-transit.tf
+++ b/subnet-transit.tf
@@ -6,8 +6,9 @@ resource "aws_subnet" "transit" {
     local.transit_newbits_effective,
     count.index + var.transit_netnum_offset,
   )
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = true
+  availability_zone                   = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch             = true
+  private_dns_hostname_type_on_launch = var.transit_hostname_type
 
   tags = merge(
     var.tags,


### PR DESCRIPTION
This introduces a hostname-type variable for each type of subnet. It allows the module user to target the underlying [private_dns_hostname_type_on_launch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#private_dns_hostname_type_on_launch-1) argument which determines whether EC2 instance hostnames are `ip-name` or `resource-name`.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...